### PR TITLE
Ensure enforce-all-checks is always ignored

### DIFF
--- a/.github/workflows/check-enforce-all-checks.yaml
+++ b/.github/workflows/check-enforce-all-checks.yaml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   enforce-all-checks:
+    name: Enforce all checks pass
     runs-on: ubuntu-latest
     permissions:
       checks: read
@@ -12,4 +13,8 @@ jobs:
       - name: GitHub Checks
         uses: poseidon/wait-for-status-checks@899c768d191b56eef585c18f8558da19e1f3e707 # v0.6.0
         with:
+          # Ignore and ignore_pattern need to contain name of the job and it
+          # isn't available in any context.
+          ignore: "Enforce all checks pass"
+          ignore_pattern: ".*\\/ Enforce all checks pass$"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use ignore_pattern to ensure that enforce-all-checks is ignored even when executed as reused workflow.
Set also a friendly name for the job and ignore it explicitly.