### PR TITLE
CI: Remove check for github-actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,6 @@ permissions:
   contents: read
 
 jobs:
-  check-github-actions:
-    uses: ./.github/workflows/check-github-actions.yaml
   check-prettier:
     uses: ./.github/workflows/check-prettier.yaml
   check-renovate-config:
@@ -23,7 +21,6 @@ jobs:
 
   check:
     needs:
-      - check-github-actions
       - check-prettier
       - check-renovate-config
       - check-yarn

--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
   "packageManager": "yarn@4.9.2",
   "private": true,
   "devDependencies": {
-    "@action-validator/cli": "0.6.0",
-    "@action-validator/core": "0.6.0",
     "prettier": "3.5.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,33 +5,6 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@action-validator/cli@npm:0.6.0":
-  version: 0.6.0
-  resolution: "@action-validator/cli@npm:0.6.0"
-  dependencies:
-    chalk: "npm:5.2.0"
-  peerDependencies:
-    "@action-validator/core": 0.6.0
-  bin:
-    action-validator: cli.mjs
-  checksum: 10c0/78d8bec3fc8a12463e2f17d93e211b2800ac8b289a996aac6116d0827db18d4b2b0bbc651aada1de53eb0a526d2c034e1151bea843b6f11b0d0b54247494c5a6
-  languageName: node
-  linkType: hard
-
-"@action-validator/core@npm:0.6.0":
-  version: 0.6.0
-  resolution: "@action-validator/core@npm:0.6.0"
-  checksum: 10c0/026967e1c3bda47b67c06f976ff427e57ec266f8b32ee2e99c8b7d1ac73fb11082622a7c2010544a220f47f4724a265ff6db4069b18cb78cce58f1e717694977
-  languageName: node
-  linkType: hard
-
-"chalk@npm:5.2.0":
-  version: 5.2.0
-  resolution: "chalk@npm:5.2.0"
-  checksum: 10c0/8a519b35c239f96e041b7f1ed8fdd79d3ca2332a8366cb957378b8a1b8a4cdfb740d19628e8bf74654d4c0917aa10cf39c20752e177a1304eac29a1168a740e9
-  languageName: node
-  linkType: hard
-
 "prettier@npm:3.5.3":
   version: 3.5.3
   resolution: "prettier@npm:3.5.3"
@@ -45,8 +18,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@action-validator/cli": "npm:0.6.0"
-    "@action-validator/core": "npm:0.6.0"
     prettier: "npm:3.5.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
The tool used for that check doesn't support the full schema of what github action and workflow yamls can contain. Notably, path globs are not supported very well. In addition the tool doesn't seem to be maintained very actively.

Now that the PR required checks are not going to allow merging if Github refuses to parse the workflow files, let's rely on Github validating and showing errors in these files. Previously when the required check was based on poseidon/wait-for-status-checks action, that would had been a problem as parse error caused job not to start and that action ended up giving green light for merging.

The shared github action for checking github-actions will be removed later when it is no longer referenced by any other repository.