### PR TITLE
renovate: Attempt to not pin node in mise.toml

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,12 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>nikobockerman/renovate-config"],
+  packageRules: [
+    {
+      description: "Don't pin node",
+      matchManagers: ["mise"],
+      matchDepNames: ["node"],
+      rangeStrategy: "update-lockfile",
+    },
+  ],
 }


### PR DESCRIPTION
The only reason node is specified in mise.toml is to ensure that the other tools run under compatible node version. This is why it's not desired to pin it in the configuration file.

However, it is locked still in the lock file to ensure CI stability and renovate should bump that one when there is new version.