### PR TITLE
renovate: Remove obsolete no-pin node rule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,12 +1,4 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>nikobockerman/renovate-config"],
-  packageRules: [
-    {
-      description: "Don't pin node",
-      matchManagers: ["mise"],
-      matchDepNames: ["node"],
-      rangeStrategy: "update-lockfile",
-    },
-  ],
 }


### PR DESCRIPTION
This rule is now enabled through shared base configuration.